### PR TITLE
feat(keyboard): add keyboard dismiss mode to contact page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ yarn-error.*
 # Images de issues
 images/*
 !images/.gitkeep
+
+pnpm-lock.yaml

--- a/app/(settings)/contact.tsx
+++ b/app/(settings)/contact.tsx
@@ -153,7 +153,11 @@ ${username}
     };
 
     return (
-        <Page style={styles.container} scrollable={true}>
+        <Page
+            style={styles.container}
+            scrollable={true}
+            keyboardDismissMode="on-drag"
+        >
             <PageHeader title="Contact" returnTo="Profil"></PageHeader>
             <View style={styles.responsiveContainer}>
                 <Bold style={styles.sectionTitle}>Formulaire de contact</Bold>

--- a/components/Page.tsx
+++ b/components/Page.tsx
@@ -12,6 +12,7 @@ export function Page(props: {
     children?: ReactNode;
     style?: any;
     scrollable?: boolean;
+    keyboardDismissMode?: "none" | "on-drag" | "interactive";
 }) {
     const contentStyle = [
         pageStyles.content,
@@ -29,6 +30,7 @@ export function Page(props: {
                 contentContainerStyle={contentStyle}
                 scrollEnabled={props.scrollable}
                 keyboardShouldPersistTaps="handled"
+                keyboardDismissMode={props.keyboardDismissMode}
             >
                 {props.children}
             </ScrollView>


### PR DESCRIPTION
This pull request enhances the user experience on the contact page by allowing the keyboard to be dismissed with a drag gesture, which is especially useful on mobile devices. The implementation involves updating the `Page` component to support a new prop for keyboard dismissal mode and applying it in the contact page.

**Contact page usability improvement:**

* Added the `keyboardDismissMode="on-drag"` prop to the `Page` component in `app/(settings)/contact.tsx` to allow users to dismiss the keyboard by dragging.

**Component extensibility:**

* Updated the `Page` component in `components/Page.tsx` to accept an optional `keyboardDismissMode` prop, supporting values `"none"`, `"on-drag"`, and `"interactive"`.
* Passed the `keyboardDismissMode` prop to the underlying `ScrollView` in `components/Page.tsx`, enabling the new keyboard dismissal behavior.

Fix the issue #83 