### PR TITLE
fix: fix a typo in credit

### DIFF
--- a/app/(settings)/credits.tsx
+++ b/app/(settings)/credits.tsx
@@ -41,7 +41,7 @@ export default function Credits() {
                 <Bold style={styles.sectionTitle}>À propos</Bold>
                 <Text style={styles.paragraph}>
                     <Text style={styles.important}>Studysen</Text> est une
-                    application crée par le club <Bold>Appen</Bold> du campus de
+                    application créée par le club <Bold>Appen</Bold> du campus de
                     Nantes de l'école d'ingénieur ISEN.
                 </Text>
                 <Text style={styles.paragraph}>


### PR DESCRIPTION
This pull request makes a minor correction to the French text in the `Credits` component, fixing a grammatical error in the word "créée".